### PR TITLE
Add customer ID to get_by_id

### DIFF
--- a/nodeping_api/get_checks.py
+++ b/nodeping_api/get_checks.py
@@ -109,8 +109,9 @@ class GetChecks:
         specified ID. Returns the contents for that check
         """
 
-        url = "{0}checks/{1}?token={2}".format(API_URL,
-                                               self.checkid, self.token)
+        
+        url = "{0}checks/{1}?token={2}&customerid={3}".format(API_URL,
+                                               self.checkid, self.token, self.customerid)
 
         return _query_nodeping_api.get(url)
 


### PR DESCRIPTION
This permits the GetChecks.get_by_id() call to return check data for sub-accounts